### PR TITLE
docs: add contributing requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 Adds the regional QuickConnect portal host returned by Synology relay metadata to the resolver candidate list, deduplicates candidates, and enforces the intended per-candidate ping timeout.
 
+### docs: Add contributing requirements — closes #10
+
+Adds contributor rules matching the issue-first, architecture-impact, changelog, and CI gates used by `ForkTheGhost/Skills`.
+
 ## 2026.04.24.2
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to VertigoRay/obsidian-synology-sync
+
+## Issues
+
+All features and bug reports must be tracked as GitHub Issues before any work begins. Issues are the authoritative record of intent; PRs without a corresponding issue will not be merged.
+
+Issues must identify:
+- What behavior the fix/feature should produce (testable acceptance criteria)
+- Whether `ARCHITECTURE.md` needs updating; any change to CI workflows, repository structure, build/release structure, or documented runtime architecture that is not already described in `ARCHITECTURE.md` must include an architecture update in the same PR
+
+## Code, Docs, or Plugin Changes
+
+1. Open a GitHub Issue describing the change and its expected behavior.
+2. Create a branch: `feat/<short-name>`, `fix/<short-name>`, `docs/<short-name>`, or `chore/<short-name>`.
+3. Make the smallest focused change that satisfies the issue acceptance criteria.
+4. Run the relevant local checks:
+   - `npm exec jest -- --runInBand`
+   - `npm run build`
+5. Open a PR referencing the issue.
+
+Documentation-only changes do not require a build if they do not affect generated plugin artifacts.
+
+## Changing Infra
+
+Changes to `.github/workflows/`, build tooling, release packaging, repository structure, or other project infrastructure must include an `ARCHITECTURE.md` update in the same PR when that structure is not already documented. PRs labeled `bug` are exempt from architecture-update enforcement unless they intentionally change architecture.
+
+## Pull Requests
+
+All changes require a PR against `main`. Direct commits to `main` are not permitted.
+
+**PR requirements:**
+- Reference the issue in the PR description (`Closes #N` or `Ref #N`)
+- Include a `CHANGELOG.md` entry under `## [Unreleased]`
+- CI must pass before merge
+
+## CHANGELOG Format
+
+```markdown
+### <type>: <short description> (`<commit-sha>`) — closes #N
+
+One or two sentences describing what changed and why.
+```
+
+Types: `feat`, `fix`, `docs`, `chore`, `decision`.
+
+`decision` entries document architectural or policy choices with no direct code change; preserve them long-term.


### PR DESCRIPTION
## Summary

Adds `CONTRIBUTING.md` with the same issue-first and PR requirements used by `ForkTheGhost/Skills`, adapted for this Obsidian plugin repo.

## Changes

- Require GitHub Issues before feature or bugfix work begins
- Require testable acceptance criteria and an architecture-impact callout in issues
- Require PRs against `main`, issue references, `CHANGELOG.md` entries under `## [Unreleased]`, and passing CI
- Replace skill-specific instructions with plugin code/docs/build workflow guidance
- Add the required changelog entry

## Verification

Docs-only change; no build required.

Closes #10