### PR TITLE
Polish strict-create error discrimination docs

### DIFF
--- a/src/filestation.ts
+++ b/src/filestation.ts
@@ -81,10 +81,11 @@ function isLikelyHtmlResponse(error: unknown): boolean {
   return /invalid json/i.test(msg) || /unexpected token\s*</i.test(msg) || msg.includes("<!DOCTYPE") || msg.includes("<html");
 }
 
-// DSM File Station errors use a documented top-level `error.code` and, for
-// batch operations, per-item details under `error.errors[].code`. Walk only
-// those paths so unrelated nested `code` fields cannot be mistaken for the
-// operation error.
+// DSM File Station errors follow a documented shape: a top-level `error.code`
+// and, for batch operations, per-item details under `error.errors[].code`.
+// Walk only those paths instead of recursing through arbitrary nested objects
+// so unrelated `code` properties on future response shapes cannot be misread
+// as the operation's error code.
 function toNumericCode(value: unknown): number | undefined {
   if (typeof value === "number") return value;
   if (typeof value === "string" && /^\d+$/.test(value)) return Number(value);
@@ -631,8 +632,10 @@ export class FileStation {
   // DSM serializing concurrent CreateFolder calls with force_parent=false; this
   // assumption is not yet validated by a multi-writer concurrency test, and the
   // lease layer built on top must not treat it as a guarantee. Callers must
-  // ensure the parent directory exists separately so lock contention can be told
-  // apart from a missing lock directory via FileStationApiError.code.
+  // ensure the parent directory exists separately — when the parent is missing
+  // DSM returns a non-exists error code which surfaces as a FileStationApiError
+  // (distinct from FileStationPathExistsError) so lock contention can be told
+  // apart from a missing lock directory without string-matching.
   async createFolderStrict(folderPath: string, name: string): Promise<void> {
     await this.createFolderInternal(folderPath, name, false, true);
   }
@@ -664,7 +667,6 @@ export class FileStation {
       // exists" (414) for non-strict callers.
       return;
     }
-
     const failureCode = findFileStationErrorCode(cfData.error);
     throw new FileStationApiError(`${label} failed: ${JSON.stringify(cfData.error)}`, failureCode);
   }

--- a/tests/filestation.spec.ts
+++ b/tests/filestation.spec.ts
@@ -319,6 +319,19 @@ describe("FileStation", () => {
       });
     });
 
+    it("recognizes numeric string already-exists codes from File Station", async () => {
+      const fs = makeFs();
+      mockedRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: { success: false, error: { code: "414" } },
+      });
+
+      await expect(fs.createFolderStrict("/repo.git/.synology-sync/locks", "main.lock")).rejects.toMatchObject({
+        name: "FileStationPathExistsError",
+        code: 414,
+      });
+    });
+
     it("preserves legacy createFolder behavior by forcing parents and ignoring already-exists", async () => {
       const fs = makeFs();
       mockedRequestUrl.mockResolvedValueOnce({

--- a/tests/filestation.spec.ts
+++ b/tests/filestation.spec.ts
@@ -356,9 +356,12 @@ describe("FileStation", () => {
       expect((err as FileStationApiError).code).toBe(119);
     });
 
-    it("does not treat unrelated nested code properties as the FileStation error code", async () => {
+    it("does not treat unrelated nested `code` properties as the FileStation error code", async () => {
       const fs = makeFs();
-      // The extractor intentionally only walks error.code and error.errors[].code.
+      // A future response shape might include a `code` inside an unrelated
+      // metadata field. The tightened extractor must only walk
+      // `error.code` and `error.errors[].code`, so this is a generic failure
+      // — not an already-exists.
       mockedRequestUrl.mockResolvedValueOnce({
         status: 200,
         json: { success: false, error: { code: 400, metadata: { code: 1100 } } },


### PR DESCRIPTION
## Architectural review of #101

PR #101 is superseded by the already-merged #97/#99/#100 stack. Keeping the original branch would regress main by removing the lease abstraction, config policy, smoke workflow, and publish-safety follow-up.

The only unique value left in #101 was non-regressing strict-create/error-discrimination polish:

- clearer DSM error-shape comment: only `error.code` and `error.errors[].code` are inspected
- clearer `createFolderStrict` contract around missing parents surfacing as `FileStationApiError`, not `FileStationPathExistsError`
- clearer regression-test wording for unrelated nested `code` properties
- additional coverage for numeric string File Station exists codes, e.g. `{ code: "414" }`

This PR extracts that safe residue onto current `main`; it intentionally does not carry #101's stale architecture/doc deletions or rollback of #99/#100.

## Validation

- `npm test -- --runInBand` - 186/186 passed
- `npm run build` - passed
- `git diff --check` - passed
