### PR TITLE
Cache successful QuickConnect candidates

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { FileStation, FileStationConfig, LoginResult } from "./filestation";
 import { resolveQuickConnect, resolveQuickConnectCandidates, probeQuickConnectCandidates, QCCandidate } from "./quickconnect";
 import { SyncEngine, SyncResult } from "./sync";
 import { MobileGitFileStationSyncEngine } from "./git-filestation-mobile";
-import { SynologySyncSettings, SynologySyncSettingTab, DEFAULT_SETTINGS, LATEST_SYNC_LOG_NOTE_PATH, migrateLoadedSettings, sanitizeSyncBackendForRuntime } from "./settings";
+import { CachedQuickConnectCandidate, SynologySyncSettings, SynologySyncSettingTab, DEFAULT_SETTINGS, LATEST_SYNC_LOG_NOTE_PATH, migrateLoadedSettings, sanitizeSyncBackendForRuntime } from "./settings";
 import { beginDebugSync, debugLog, endDebugSync, formatErrorForDebug, getDebugLog, logRuntimeDiagnostics, redactSensitiveLogText } from "./debug";
 
 // UUID generator with fallbacks for older runtimes.
@@ -43,6 +43,49 @@ export function sameQuickConnectCandidate(a: QCCandidate, b: QCCandidate): boole
 export function moveCandidateToFront(candidates: QCCandidate[], selected: QCCandidate): QCCandidate[] {
   const rest = candidates.filter((candidate) => !sameQuickConnectCandidate(candidate, selected));
   return [selected, ...rest];
+}
+
+const QUICKCONNECT_CANDIDATE_CACHE_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+const QUICKCONNECT_CANDIDATE_CACHE_LIMIT = 5;
+
+function candidateUrl(candidate: QCCandidate): string {
+  return `${candidate.https ? "https" : "http"}://${candidate.host}:${candidate.port}`;
+}
+
+function normalizedQuickConnectId(id: string): string {
+  return id.trim().toLowerCase();
+}
+
+export function prioritizeCachedQuickConnectCandidates(
+  discovered: QCCandidate[],
+  cached: CachedQuickConnectCandidate[],
+  quickConnectId: string,
+  now = Date.now(),
+): QCCandidate[] {
+  const normalizedId = normalizedQuickConnectId(quickConnectId);
+  const fresh = freshCachedQuickConnectCandidates(cached, normalizedId, now);
+
+  const out: QCCandidate[] = [];
+  for (const candidate of [...fresh, ...discovered]) {
+    if (!out.some((existing) => sameQuickConnectCandidate(existing, candidate))) out.push(candidate);
+  }
+  return out;
+}
+
+export function freshCachedQuickConnectCandidates(
+  cached: CachedQuickConnectCandidate[],
+  quickConnectId: string,
+  now = Date.now(),
+): QCCandidate[] {
+  const normalizedId = normalizedQuickConnectId(quickConnectId);
+  return cached
+    .filter((entry) => normalizedQuickConnectId(entry.quickConnectId) === normalizedId)
+    .filter((entry) => now - entry.lastSuccessAt <= QUICKCONNECT_CANDIDATE_CACHE_TTL_MS)
+    .sort((a, b) => {
+      if (b.lastSuccessAt !== a.lastSuccessAt) return b.lastSuccessAt - a.lastSuccessAt;
+      return b.successCount - a.successCount;
+    })
+    .map((entry) => entry.candidate);
 }
 
 export default class SynologySync extends Plugin {
@@ -173,14 +216,61 @@ export default class SynologySync extends Plugin {
 
 
   private async prioritizedQuickConnectCandidates(quickConnectId: string): Promise<QCCandidate[]> {
-    const candidates = await resolveQuickConnectCandidates(quickConnectId);
-    const reachable = await probeQuickConnectCandidates(candidates);
-    if (reachable) return moveCandidateToFront(candidates, reachable);
+    const candidates = await resolveQuickConnectCandidates(quickConnectId, this.settings.debugQuickConnectResolution);
+    const freshCachedCandidates = freshCachedQuickConnectCandidates(this.settings.quickConnectCandidateCache || [], quickConnectId);
+    if (freshCachedCandidates.length > 0) {
+      debugLog(`QC: trying ${freshCachedCandidates.length} cached working candidate(s) before rediscovery probes`);
+      return prioritizeCachedQuickConnectCandidates(candidates, this.settings.quickConnectCandidateCache || [], quickConnectId);
+    }
+    const cachedCandidates = prioritizeCachedQuickConnectCandidates(
+      candidates,
+      this.settings.quickConnectCandidateCache || [],
+      quickConnectId,
+    );
+    if (this.settings.debugQuickConnectResolution) {
+      debugLog(`QC: working-candidate cache entries=${(this.settings.quickConnectCandidateCache || []).length} candidates_after_cache=${cachedCandidates.length}`);
+      cachedCandidates.forEach((candidate, i) => debugLog(`QC: priority [${i}] ${candidateUrl(candidate)} (${candidate.kind})`));
+    }
+    const candidatesToProbe = cachedCandidates;
+    const reachable = await probeQuickConnectCandidates(candidatesToProbe);
+    if (reachable) return moveCandidateToFront(candidatesToProbe, reachable);
 
-    const slowReachable = await probeQuickConnectCandidates(candidates, 30000);
-    if (slowReachable) return moveCandidateToFront(candidates, slowReachable);
+    const slowReachable = await probeQuickConnectCandidates(candidatesToProbe, 30000);
+    if (slowReachable) return moveCandidateToFront(candidatesToProbe, slowReachable);
 
-    return candidates;
+    return candidatesToProbe;
+  }
+
+  private async recordQuickConnectCandidateResult(quickConnectId: string, candidate: QCCandidate, success: boolean): Promise<void> {
+    const now = Date.now();
+    const normalizedId = normalizedQuickConnectId(quickConnectId);
+    const retained = (this.settings.quickConnectCandidateCache || [])
+      .filter((entry) => normalizedQuickConnectId(entry.quickConnectId) === normalizedId || now - entry.lastSuccessAt <= QUICKCONNECT_CANDIDATE_CACHE_TTL_MS)
+      .filter((entry) => now - entry.lastSuccessAt <= QUICKCONNECT_CANDIDATE_CACHE_TTL_MS);
+    const existing = retained.find((entry) => normalizedQuickConnectId(entry.quickConnectId) === normalizedId && sameQuickConnectCandidate(entry.candidate, candidate));
+    if (existing) {
+      existing.lastTriedAt = now;
+      if (success) {
+        existing.lastSuccessAt = now;
+        existing.successCount += 1;
+      } else {
+        existing.lastFailureAt = now;
+      }
+    } else if (success) {
+      retained.push({
+        candidate,
+        quickConnectId: normalizedId,
+        successCount: 1,
+        lastSuccessAt: now,
+        lastTriedAt: now,
+      });
+    }
+    retained.sort((a, b) => b.lastSuccessAt - a.lastSuccessAt || b.successCount - a.successCount);
+    this.settings.quickConnectCandidateCache = retained.slice(0, QUICKCONNECT_CANDIDATE_CACHE_LIMIT);
+    if (this.settings.debugQuickConnectResolution) {
+      debugLog(`QC: working-candidate cache ${success ? "recorded success" : "recorded failure"} ${candidateUrl(candidate)} entries=${this.settings.quickConnectCandidateCache.length}`);
+    }
+    await this.saveSettings();
   }
 
   async getFileStation(): Promise<FileStation> {
@@ -196,6 +286,7 @@ export default class SynologySync extends Plugin {
         try {
           const result = await fs.login();
           debugLog(`QC: authenticated candidate [${i}] ${config.baseUrl}`);
+          await this.recordQuickConnectCandidateResult(this.settings.quickConnectId, candidate, true);
           if (result.deviceToken && result.deviceToken !== this.settings.deviceToken) {
             this.settings.deviceId = result.deviceId;
             this.settings.deviceToken = result.deviceToken;
@@ -205,6 +296,7 @@ export default class SynologySync extends Plugin {
         } catch (e) {
           lastError = e;
           debugLog(`QC: candidate [${i}] failed: ${(e as Error).message}`);
+          await this.recordQuickConnectCandidateResult(this.settings.quickConnectId, candidate, false);
           try { await fs.logout(); } catch { /* ignore */ }
         }
       }

--- a/src/quickconnect.ts
+++ b/src/quickconnect.ts
@@ -188,7 +188,7 @@ async function requestTunnelServerInfo(quickConnectId: string, results: QCServer
   return [];
 }
 
-export async function resolveQuickConnectCandidates(quickConnectId: string): Promise<QCCandidate[]> {
+export async function resolveQuickConnectCandidates(quickConnectId: string, debugResolution = false): Promise<QCCandidate[]> {
   debugLog(`QC: resolving "${quickConnectId}"`);
   const normalizedQuickConnectId = normalizeQuickConnectId(quickConnectId);
   const body = buildServerInfoBody(quickConnectId);
@@ -222,6 +222,34 @@ export async function resolveQuickConnectCandidates(quickConnectId: string): Pro
   // SmartDNS hostnames have valid wildcard certs under *.direct.quickconnect.to,
   // so HTTPS works without self-signed cert errors (even for LAN IPs).
   const candidates: QCCandidate[] = [];
+
+  results.forEach((info, index) => {
+    if (!debugResolution) return;
+    const svc = info.service || {} as QCServerInfo["service"];
+    const srv = info.server || {} as QCServerInfo["server"];
+    const dns = info.smartdns;
+    debugLog([
+      `QC: server-info[${index}] fields`,
+      `errno=${info.errno ?? 0}`,
+      `command=${info.command || "(unset)"}`,
+      `relay_region=${info.env?.relay_region ? "present" : "absent"}`,
+      `service.port=${svc.port || "absent"}`,
+      `service.ext_port=${svc.ext_port || "absent"}`,
+      `service.relay_port=${svc.relay_port || "absent"}`,
+      `service.relay_dn=${svc.relay_dn ? "present" : "absent"}`,
+      `service.relay_ip=${svc.relay_ip ? "present" : "absent"}`,
+      `service.relay_dualstack=${svc.relay_dualstack ? "present" : "absent"}`,
+      `service.https_ip=${svc.https_ip ? "present" : "absent"}`,
+      `service.https_port=${svc.https_port || "absent"}`,
+      `smartdns.host=${dns?.host ? "present" : "absent"}`,
+      `smartdns.external=${dns?.external ? "present" : "absent"}`,
+      `smartdns.lan=${dns?.lan?.length || 0}`,
+      `server.fqdn=${srv.fqdn && srv.fqdn !== "NULL" ? "present" : "absent"}`,
+      `server.ddns=${srv.ddns && srv.ddns !== "NULL" ? "present" : "absent"}`,
+      `server.interface=${srv.interface?.length || 0}`,
+      `server.external=${srv.external?.ip && srv.external.ip !== "0.0.0.0" ? "present" : "absent"}`,
+    ].join(" "));
+  });
 
   for (const info of results) {
     if (info.errno) continue;
@@ -308,7 +336,7 @@ export async function resolveQuickConnectCandidates(quickConnectId: string): Pro
   }
 
   debugLog(`QC: ${candidates.length} candidates built`);
-  candidates.forEach((c, i) => debugLog(`QC:   [${i}] ${c.https ? "https" : "http"}://${c.host}:${c.port}`));
+  candidates.forEach((c, i) => debugLog(`QC:   [${i}] ${c.https ? "https" : "http"}://${c.host}:${c.port} (${c.kind})`));
 
   return candidates;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,16 @@ import { resolveQuickConnect } from "./quickconnect";
 import { getDebugLog, getDebugLogSnippet, clearDebugLog, subscribeDebugLog } from "./debug";
 import { FileStation, FileInfo } from "./filestation";
 import type { ObsidianConfigOptIns, ObsidianConfigSyncPolicy } from "./git-excludes";
+import type { QCCandidate } from "./quickconnect";
+
+export interface CachedQuickConnectCandidate {
+  candidate: QCCandidate;
+  quickConnectId: string;
+  successCount: number;
+  lastSuccessAt: number;
+  lastTriedAt?: number;
+  lastFailureAt?: number;
+}
 
 export interface SynologySyncSettings {
   syncBackend: "filestation" | "git-filestation";
@@ -57,6 +67,8 @@ export interface SynologySyncSettings {
   gitAuthorEmail: string;
   obsidianConfigPolicy: ObsidianConfigSyncPolicy;
   obsidianConfigOptIns: ObsidianConfigOptIns;
+  debugQuickConnectResolution: boolean;
+  quickConnectCandidateCache: CachedQuickConnectCandidate[];
   persistSyncLogToVaultNote: boolean;
 }
 
@@ -103,6 +115,8 @@ export const DEFAULT_SETTINGS: SynologySyncSettings = {
   gitAuthorEmail: "synology-sync@local",
   obsidianConfigPolicy: "notes-only",
   obsidianConfigOptIns: {},
+  debugQuickConnectResolution: false,
+  quickConnectCandidateCache: [],
   persistSyncLogToVaultNote: false,
 };
 
@@ -117,6 +131,14 @@ const LEGACY_TOMBSTONE_JITTER_MS = 30000;
  */
 export function migrateLoadedSettings(settings: SynologySyncSettings): boolean {
   let changed = false;
+  if (!Array.isArray(settings.quickConnectCandidateCache)) {
+    settings.quickConnectCandidateCache = [];
+    changed = true;
+  }
+  if (typeof settings.debugQuickConnectResolution !== "boolean") {
+    settings.debugQuickConnectResolution = false;
+    changed = true;
+  }
   if (settings.tombstoneJitterMs === LEGACY_TOMBSTONE_JITTER_MS) {
     settings.tombstoneJitterMs = DEFAULT_SETTINGS.tombstoneJitterMs;
     changed = true;
@@ -571,6 +593,16 @@ export class SynologySyncSettingTab extends PluginSettingTab {
       .addToggle((toggle) =>
         toggle.setValue(this.plugin.settings.persistSyncLogToVaultNote).onChange(async (value) => {
           this.plugin.settings.persistSyncLogToVaultNote = value;
+          await this.plugin.saveSettings();
+        })
+      );
+
+    new Setting(containerEl)
+      .setName("Debug QuickConnect resolution")
+      .setDesc("Log sanitized QuickConnect server-info field presence and working-candidate cache decisions. Useful for off-LAN relay troubleshooting.")
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.debugQuickConnectResolution).onChange(async (value) => {
+          this.plugin.settings.debugQuickConnectResolution = value;
           await this.plugin.saveSettings();
         })
       );

--- a/tests/main-quickconnect.spec.ts
+++ b/tests/main-quickconnect.spec.ts
@@ -1,4 +1,4 @@
-import { moveCandidateToFront } from "../src/main";
+import { moveCandidateToFront, prioritizeCachedQuickConnectCandidates } from "../src/main";
 import type { QCCandidate } from "../src/quickconnect";
 
 describe("QuickConnect candidate prioritization", () => {
@@ -11,5 +11,32 @@ describe("QuickConnect candidate prioritization", () => {
 
     expect(moveCandidateToFront(candidates, candidates[0])).toEqual(candidates);
     expect(moveCandidateToFront(candidates, candidates[1])).toEqual([candidates[1], candidates[0], candidates[2]]);
+  });
+
+  it("tries recently successful QuickConnect candidates before rediscovered candidates", () => {
+    const now = Date.UTC(2026, 4, 27);
+    const portal: QCCandidate = { host: "portal.example", port: 443, https: true, kind: "portal" };
+    const direct: QCCandidate = { host: "direct.example", port: 5001, https: true, kind: "api" };
+    const relay: QCCandidate = { host: "relay.example", port: 32836, https: true, kind: "relay-api" };
+
+    expect(prioritizeCachedQuickConnectCandidates([portal, direct], [{
+      candidate: relay,
+      quickConnectId: "example-nas",
+      successCount: 2,
+      lastSuccessAt: now - 60_000,
+    }], "Example-NAS", now)).toEqual([relay, portal, direct]);
+  });
+
+  it("drops stale cached QuickConnect candidates from priority order", () => {
+    const now = Date.UTC(2026, 4, 27);
+    const portal: QCCandidate = { host: "portal.example", port: 443, https: true, kind: "portal" };
+    const staleRelay: QCCandidate = { host: "relay.example", port: 32836, https: true, kind: "relay-api" };
+
+    expect(prioritizeCachedQuickConnectCandidates([portal], [{
+      candidate: staleRelay,
+      quickConnectId: "example-nas",
+      successCount: 10,
+      lastSuccessAt: now - 15 * 24 * 60 * 60 * 1000,
+    }], "Example-NAS", now)).toEqual([portal]);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a working QuickConnect candidate cache so the last successful endpoint is tried before rediscovery/probe ordering.
- Adds stale cache expiry and caps retained entries.
- Adds a settings toggle for sanitized QuickConnect resolution diagnostics.
- Logs sanitized server-info field presence when the toggle is enabled, so we can distinguish missing relay fields from parser/candidate-builder issues.

## Why
For off-LAN QuickConnect, direct `:5001` routes can be expected to fail when DSM is not exposed. If a relay/API route worked previously, the plugin should try that known-good route first and only fall back to rediscovery when known-good candidates fail or expire.

## Validation
- `npm test -- --runInBand tests/main-quickconnect.spec.ts tests/quickconnect.spec.ts`
- `npm run lint`
